### PR TITLE
docs: update OSS maintenance plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,13 @@
-# Boostimer - Product Availability Countdown And Scheduler For Woocommerce
+# Boostimer - Product Availability Countdown and Scheduler for WooCommerce
 
 **Contributors:** [zabiranik](https://profiles.wordpress.org/zabiranik/)  
 **Donate link:** [zabiranik/donate](https://www.buymeacoffee.com/zabiranik)  
 **Requires at least:** 5.0  
-**Tested up to:** 5.9  
+**Tested up to:** 6.7.1  
 **Stable tag:** 1.5.0  
 **Requires PHP:** 5.6  
 **License:** GPLv2 or later  
 **License URI:** https://www.gnu.org/licenses/gpl-2.0.html
-
-## Contributing to Boostimer
-If you want to contribute to Boostimer, please check out [Contribute to Boostimer](https://github.com/xaviranik/boostimer/blob/develop/CONTRIBUTING.md)
 
 ## Description
 
@@ -28,15 +25,15 @@ Using this plugin, it’s easy to know when the required product will be availab
 
 ### Key Features
 
--   Display a countdown timer to highlight when the product will be restocked.
--   Display a countdown timer to highlight sale products purchase availability end days and time.
--   Display Restock timer automatically after Sale timer when the stock goes zero.
--   Manages Restock and Sale countdown for stock quantity.
--   Display Sale timer and Restock timer countdown for Simple Product.
--   Display Restock timer countdown for Variable Product.
--   Display Sale timer countdown for External/Affiliate Product.
--   Customize Sale Timer and Restock Timer title.
--   Works seamlessly with [WooCommerce Subscriptions](https://woocommerce.com/products/woocommerce-subscriptions/) product - Simple, Variable.
+- Display a countdown timer to highlight when the product will be restocked.
+- Display a countdown timer to highlight sale products purchase availability end days and time.
+- Display Restock timer automatically after Sale timer when the stock goes zero.
+- Manages Restock and Sale countdown for stock quantity.
+- Display Sale timer and Restock timer countdown for Simple Product.
+- Display Restock timer countdown for Variable Product.
+- Display Sale timer countdown for External/Affiliate Product.
+- Customize Sale Timer and Restock Timer title.
+- Works seamlessly with [WooCommerce Subscriptions](https://woocommerce.com/products/woocommerce-subscriptions/) product - Simple, Variable.
 
 ### Attractive User Interface
 
@@ -66,24 +63,43 @@ A good UI can sometimes make a system even more attractive. Boostimer has an int
 
 [![subscription-product-sale-timer](https://i.postimg.cc/wMXhtMrJ/03-subscription-product-sale-timer.png)]()
 
+## Maintenance status
+
+Boostimer is maintained as an open-source WordPress/WooCommerce plugin. Current maintenance work is focused on keeping the plugin compatible with recent WordPress and WooCommerce releases, improving automated checks, reviewing dependencies, and keeping release metadata in sync across GitHub and WordPress.org assets.
+
+See [ROADMAP.md](ROADMAP.md) for the current maintenance roadmap.
+
+## Contributing to Boostimer
+
+If you want to contribute to Boostimer, please check out [Contribute to Boostimer](https://github.com/xaviranik/boostimer/blob/develop/CONTRIBUTING.md).
+
 ## Changelog
 
-### v1.3.0 (24th January 2022)
+### v1.5.0 (25th January 2025)
+
+- **Maintenance**: Bumped plugin metadata and package version to 1.5.0.
+- **Compatibility**: Synced WordPress compatibility metadata with the WordPress.org readme.
+
+### v1.4.0 (18th September 2022)
+
+- **Compatibility**: Compatibility for WordPress 6.7.1
+
+### v1.3.0 (18th September 2022)
 
 - **Compatibility**: Compatibility for WordPress 6.0.2
 
-### v1.2.0 (24th January 2022)
+### v1.2.0 (24th January 2021)
 
 - **Compatibility**: Compatibility for WordPress 5.9
 
 ### v1.1.0 (6th January 2021)
 
--   **Feature**: Date prompt on WooCommerce product listing page / Shop Page
--   **Enhancement**: Asset loading optimization
+- **Feature**: Date prompt on WooCommerce product listing page / Shop Page
+- **Enhancement**: Asset loading optimization
 
 ### v1.0.0 (27th November 2021)
 
--   Initial Release
+- Initial Release
 
 ## Upgrade Notice
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -28,17 +28,6 @@ This roadmap tracks maintenance work that helps keep Boostimer reliable for WooC
 - Add release notes that explain compatibility changes and any migration notes for store owners.
 - Keep contribution guidance aligned with the current build and test workflow.
 
-## Potential Codex-assisted workflows
-
-Codex can help maintainers and contributors by:
-
-- Drafting focused issues from maintenance goals.
-- Reviewing pull requests for regressions, missing tests, and documentation gaps.
-- Generating test cases around WooCommerce product-type behavior.
-- Explaining legacy code paths before refactors.
-- Producing release-note drafts from merged pull requests.
-- Helping triage compatibility issues reported by WordPress/WooCommerce users.
-
 ## Contribution areas
 
 Contributors are welcome to help with:

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,50 @@
+# Boostimer Maintenance Roadmap
+
+This roadmap tracks maintenance work that helps keep Boostimer reliable for WooCommerce store owners and easier to contribute to as an open-source project.
+
+## Near-term maintenance priorities
+
+### WordPress and WooCommerce compatibility
+
+- Verify Boostimer against the latest supported WordPress and WooCommerce versions.
+- Document the local test matrix for supported PHP, WordPress, WooCommerce, and WooCommerce Subscriptions versions.
+- Keep `README.md`, `readme.txt`, plugin headers, and package metadata in sync for each release.
+
+### Automated quality checks
+
+- Add or refresh CI for PHP linting, PHPCS, JavaScript linting, and production builds.
+- Expand PHPUnit coverage for timer scheduling, product availability state transitions, and metadata handling.
+- Add smoke tests for simple, variable, external/affiliate, and subscription products.
+
+### Security and dependency review
+
+- Review PHP and JavaScript dependencies for abandoned or vulnerable packages.
+- Audit REST/API usage, nonce checks, sanitization, escaping, and capability checks.
+- Document a lightweight security review checklist for releases.
+
+### Release workflow
+
+- Make release preparation repeatable with a checklist for version bumps, changelog updates, build artifacts, and WordPress.org readme updates.
+- Add release notes that explain compatibility changes and any migration notes for store owners.
+- Keep contribution guidance aligned with the current build and test workflow.
+
+## Potential Codex-assisted workflows
+
+Codex can help maintainers and contributors by:
+
+- Drafting focused issues from maintenance goals.
+- Reviewing pull requests for regressions, missing tests, and documentation gaps.
+- Generating test cases around WooCommerce product-type behavior.
+- Explaining legacy code paths before refactors.
+- Producing release-note drafts from merged pull requests.
+- Helping triage compatibility issues reported by WordPress/WooCommerce users.
+
+## Contribution areas
+
+Contributors are welcome to help with:
+
+- Compatibility testing against current WordPress and WooCommerce releases.
+- Test coverage for sale and restock countdown behavior.
+- Documentation improvements.
+- Dependency updates.
+- Bug reports with reproduction steps and environment details.


### PR DESCRIPTION
## Summary

- sync GitHub README metadata with the WordPress.org readme compatibility signal
- add the missing v1.5.0 changelog entry to the GitHub README
- add a maintainer roadmap covering compatibility, automated checks, security/dependency review, and release workflow

## Notes

This is a documentation-only PR intended to make the repository maintenance direction clearer for contributors and future OSS support applications.

## Testing

- Not run; documentation-only changes.